### PR TITLE
Build docker image in jdk and run in jre

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,4 @@ RUN mvn install
 FROM openjdk:8-jre-alpine
 COPY --from=builder /usr/src/app/target/ .
 
-ENTRYPOINT ["java", "-jar", "core-grpc-jdbc-connector-0.0.1-SNAPSHOT.jar"]
+ENTRYPOINT ["java", "-jar", "core-grpc-jdbc-connector.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk
+FROM openjdk:8-jdk AS builder
 
 # ----
 # Install Maven
@@ -30,4 +30,9 @@ COPY pom.xml /usr/src/app
 COPY src /usr/src/app/src
 
 RUN mvn install
-ENTRYPOINT ["java", "-jar", "target/core-grpc-jdbc-connector-0.0.1-SNAPSHOT.jar"]
+
+# copy target from builder
+FROM openjdk:8-jre-alpine
+COPY --from=builder /usr/src/app/target/ .
+
+ENTRYPOINT ["java", "-jar", "core-grpc-jdbc-connector-0.0.1-SNAPSHOT.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,7 @@
     <artifactId>core-grpc-jdbc-connector</artifactId>
     <version>0.0.1-SNAPSHOT</version>
 
+
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -92,6 +93,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
+                    <finalName>core-grpc-jdbc-connector</finalName>
                     <archive>
                         <manifest>
                             <addClasspath>true</addClasspath>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,6 @@
     <artifactId>core-grpc-jdbc-connector</artifactId>
     <version>0.0.1-SNAPSHOT</version>
 
-
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
Build docker image in base image openjdk:8-jdk and copy to a jre base.

Image size decreases from ~800MB to ~100MB.

This closes #6 
