### PR TITLE
Catch exceptions when fetching data in reload-runner

### DIFF
--- a/example/reload-runner/index.js
+++ b/example/reload-runner/index.js
@@ -87,7 +87,7 @@ async function load() {
   try {
     await loadData(app, postgresqlConnectionSettings);
   } catch (e) {
-    console.log(`Failed to load data from PostgresSQL with error: ${e}`);
+    console.log(`Failed to load data from PostgreSQL with error: ${e}`);
     process.exit(1);
   }
 

--- a/example/reload-runner/index.js
+++ b/example/reload-runner/index.js
@@ -76,10 +76,20 @@ async function load() {
   }
 
   console.log('Loading from MySQL');
-  await loadData(app, mysqlConnectionSettings);
+  try {
+    await loadData(app, mysqlConnectionSettings);
+  } catch (e) {
+    console.log(`Failed to load data from MySQL with error: ${e}`);
+    process.exit(1);
+  }
 
   console.log('Loading from PostgreSQL');
-  await loadData(app, postgresqlConnectionSettings);
+  try {
+    await loadData(app, postgresqlConnectionSettings);
+  } catch (e) {
+    console.log(`Failed to load data from PostgresSQL with error: ${e}`);
+    process.exit(1);
+  }
 
   await global.deleteApp(appId);
 


### PR DESCRIPTION
Earlier the `reload-runner` did not catch exceptions if something failed when fetching data from the databases. This could lead to hanging builds in Circle CI since the code is used as an integration test e.g. #56.

This closes #60 