### PR TITLE
Additional JDBC driver documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
           path: ~/core-grpc-jdbc-connector
       - run:
           name: Run unittest
-          command: mvn test
+          command: mvn -B test
 workflows:
   version: 2
   build_and_test:

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Unix line endings in all text files.
 *   text eol=lf
+*.jar binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 .idea/
+.vscode/
+.settings/
 target/
 **/node_modules/
 *.iml
+.classpath
+.project

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ WORKDIR /usr/src/app
 
 # install maven dependency packages (keep in image)
 COPY pom.xml /usr/src/app
-
 COPY src /usr/src/app/src
 
 RUN mvn install

--- a/README.md
+++ b/README.md
@@ -68,6 +68,53 @@ Other JDBC Drivers can be added to the pom.xml file in the following section:
 </dependencies>
 ```
 
+Make sure you start your Qlik Associative Engine with the proper gRPC connector string to enable your JDBC driver. [See an example here](./example/docker-compose.yml).
+
+### Athena driver
+
+### Installing driver
+
+The AWS Athena driver is not officially deployed on a Maven repository, so you have to download the jar file and place it in the connector project manually.
+
+[You can download the driver here](https://docs.aws.amazon.com/athena/latest/ug/connect-with-jdbc.html).
+
+`pom.xml` entry:
+
+```xml
+<dependency>
+    <groupId>com.amazonaws.athena.jdbc</groupId>
+    <artifactId>jdbcdriver</artifactId>
+    <version>2.0.5</version>
+    <scope>system</scope>
+    <systemPath>${project.basedir}/AthenaJDBC42_2.0.5.jar</systemPath>
+</dependency>
+```
+
+`Dockerfile` entry:
+
+```
+COPY AthenaJDBC42_2.0.5.jar /usr/src/app
+```
+
+### Example configuration
+
+Connection string:
+
+```
+{
+  qType: 'jdbc',
+  qName: 'jdbc',
+  qConnectionString: 'CUSTOM CONNECT TO "provider=jdbc;driver=awsathena;AwsRegion=eu-central-1;S3OutputLocation=s3://aws-athena-query-results-athenatest1-eu-central-1"',
+  qUserName: 'AWS Key',
+  qPassword: 'AWS Token',
+}
+```
+
+LOAD statement:
+
+```
+sql SELECT * FROM yourathendatabase.yourathenatable;
+```
 
 ## License
 This repository is licensed under [MIT](/LICENSE) but components used in the Dockerfile examples are under other licenses.

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@
             <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <version>2.22.0</version>
+            <configuration>
+                <forkCount>3</forkCount>
+                <reuseForks>true</reuseForks>
+                <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+            </configuration>
             <dependencies>
                 <dependency>
                     <groupId>org.junit.platform</groupId>


### PR DESCRIPTION
There are many JDBC drivers out there that we can support using this JDBC driver.

This PR includes some specific instructions how to use AWS Athena, but can be expanded to include other drivers in the future.

There's also a fix for non-traditional JDBC drivers in the connector here, which enables us to use connector instructions that are not using the `host`, `port`, `database` schema.